### PR TITLE
Fix: 카카오 소셜 로그인 구현

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -16,7 +16,7 @@ export const login = async (req, res) => {
   } catch (errors) {
     res.status(errors.statusCode || 500).json({ message: errors.message });
   }
-}
+};
 export const kakao = async (req, res) => {
   const baseUrl = 'https://kauth.kakao.com/oauth/authorize';
   const config = {

--- a/models/user.js
+++ b/models/user.js
@@ -18,6 +18,21 @@ export const createUser = async (
   });
 };
 
+export const createSocialUser = async (id, userId) => {
+  return await prismaClient.social_login.create({
+    data: {
+      social_id: String(id),
+      user_id: userId,
+    },
+  });
+};
+
 export const readUserByEmail = async email => {
   return await prismaClient.users.findUnique({ where: { email } });
+};
+
+export const readUserBySocialId = async id => {
+  return await prismaClient.social_login.findFirst({
+    where: { social_id: String(id) },
+  });
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,9 +105,9 @@ model recent_search {
 }
 
 model social_login {
-  id      Int    @id
-  user_id Int?
-  users   users? @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "social_login_ibfk_1")
+  social_id String @id @db.VarChar(100)
+  user_id   Int?
+  users     users? @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "social_login_ibfk_1")
 
   @@index([user_id], map: "user_id")
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [] 레이아웃 구현
- [] 기능 추가
- [] 리뷰 반영
- [] 리팩토링
- [x] 버그 수정
- [] 컨벤션 수정
- [] 초기 세팅

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- social_login 테이블 추가 후 카카오 소셜 로그인 기능 구현
- 에러처리는 구현 예정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 카카오 소셜 로그인 요청이 들어오면 social_login 테이블에 해당 id의 로우가 있는지 확인
2. 있다면 토큰을 쿼리 스트링에 담아 프론트로 redirect.
3. 없다면 회원가입 로직 실행
4. 먼저 users 테이블에 카카오 서버로 부터 받은 정보를 기반으로 row를 생성하고, social_login 테이블에 카카오 서버로 부터 받은 id와 앞서 생성한 users 테이블 로우의 id를 이용하여 로우 생성
5. 생성 후 2번 로직 실행

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

-

<br />

## :: 기타 질문 및 특이 사항

-
