### PR TITLE
Add : 'pin 만들기' 화면 get 하는 api 구현 [육지]

### DIFF
--- a/controllers/pin-make.js
+++ b/controllers/pin-make.js
@@ -1,0 +1,20 @@
+import * as pinMakeService from '../services/pin-make.js';
+
+export const readMakePinPage = async (req, res) => {
+  try {
+    const userId = req.userId;
+    console.log('userId :', userId);
+
+    const makePinPage = await pinMakeService.readMakePinPage(userId);
+    const result = JSON.parse(
+      JSON.stringify(
+        makePinPage,
+        (key, value) => (typeof value === 'bigint' ? value.toString() : value) // return everything else unchanged
+      )
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/models/pin-make.js
+++ b/models/pin-make.js
@@ -1,0 +1,13 @@
+import prismaClient from './prisma-client.js';
+
+export async function readMakePinPage(userId) {
+  const makePinPage = await prismaClient.$queryRaw`
+  SELECT boards.id as board_id, boards.title, boards.cover_image_url, users.name as user_name, COUNT(followings.follower_id) as follower_count
+  FROM boards
+  JOIN users on boards.user_id = users.id
+  JOIN followings on users.id = followee_id
+  WHERE boards.user_id = ${userId}
+  GROUP BY boards.id;
+  `;
+  return makePinPage;
+}

--- a/routes/pins.js
+++ b/routes/pins.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import * as pinsController from '../controllers/pins.js';
+import * as pinsMakeController from '../controllers/pin-make.js';
 import { isLogin } from '../middleware/auth.js';
 const router = express.Router();
 
@@ -8,5 +9,6 @@ router.use(isLogin);
 router.get('/pins', pinsController.pinList);
 router.get('/pins/:pin_id', pinsController.readPinById);
 router.post('/pins/:pin_id', pinsController.savePin);
+router.get('/pin-make', pinsMakeController.readMakePinPage);
 
 export default router;

--- a/services/pin-make.js
+++ b/services/pin-make.js
@@ -1,0 +1,7 @@
+import * as pinMakeModels from '../models/pin-make.js';
+
+export async function readMakePinPage(userId) {
+  const makePinPage = await pinMakeModels.readMakePinPage(userId);
+
+  return makePinPage;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 초기 세팅

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- '핀 만들기' 화면 불러오는 API
![image](https://user-images.githubusercontent.com/89456198/178918115-3713a2a9-1a61-431e-97d3-888abc929c70.png)


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- '핀 만들기' 화면에 뿌려줄 데이터 (유저네임, 팔로워 수, 유저가 가지고 있는 보드 제목과 커버 이미지)를 가져오는 API 구현



<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 

<br />

## :: 기타 질문 및 특이 사항

- 요청 시 모양이 아래와 같이 넘어오는데 user_name과 follower_count는 한 번만 필요한 거라서
 ![image](https://user-images.githubusercontent.com/89456198/178918234-eaf1ef60-b922-4067-805b-60a251df7a5c.png)

```
[
   "user_name": "justcode",
   "follower_count": "5"
    [ {
        "board_id": 3,
        "title": "갱얼쥐사진",
        "cover_image_url": null
    },
    {
        "board_id": 4,
        "title": "저스트코드",
        "cover_image_url": null
    } ]
]
``` 
이런 모양으로 바꿔주고 싶은데 SQL 문 수정하는 게 오래 걸릴 것 같아서 일단 다른 API 구현으로 넘어가고
나중에 수정해 보려고 합니다.
