### PR TITLE
Add: 보드 병합하기 기능 구현

### DIFF
--- a/controllers/board.js
+++ b/controllers/board.js
@@ -48,3 +48,15 @@ export const readBoardDetailById = async (req, res) => {
     return res.status(error.statusCode || 500).json({ message: error.message });
   }
 };
+
+export const mergeBoard = async (req, res) => {
+  try {
+    const oldBoardId = req.params.board_id;
+    const newBoardId = req.body.new_board_id;
+    const userId = req.userId;
+    await boardService.mergeBoard(oldBoardId, newBoardId, userId);
+    res.status(200).json({ message: 'SUCCESS' });
+  } catch (error) {
+    return res.status(error.statusCode || 500).json({ message: error.message });
+  }
+};

--- a/models/board.js
+++ b/models/board.js
@@ -40,3 +40,17 @@ export const readBoardDetailById = async boardId => {
   WHERE boards.id=${boardId};
   `;
 };
+
+export const updateBoardStoreById = async (oldBoardId, newBoardId) => {
+  return prismaClient.$transaction([
+    prismaClient.board_store.updateMany({
+      where: { board_id: Number(oldBoardId) },
+      data: { board_id: Number(newBoardId) },
+    }),
+    prismaClient.boards.delete({
+      where: {
+        id: Number(oldBoardId),
+      },
+    }),
+  ]);
+};

--- a/routes/board.js
+++ b/routes/board.js
@@ -6,6 +6,7 @@ router.use(isLogin);
 
 router.post('/board', boardController.createBoard);
 router.put('/board', boardController.updateBoard);
+router.put('/board/:board_id', boardController.mergeBoard);
 router.get('/board/:board_id', boardController.readBoardDetailById);
 router.delete('/board/:board_id', boardController.deleteBoard);
 

--- a/services/board.js
+++ b/services/board.js
@@ -63,3 +63,19 @@ export const readBoardDetailById = async (boardId, userId) => {
   };
   return info;
 };
+
+export const mergeBoard = async (oldBoardId, newBoardId, userId) => {
+  const newBoardCheck = await boardRepository.readBoardById(newBoardId);
+  const oldBoardCheck = await boardRepository.readBoardById(oldBoardId);
+  if (!Boolean(newBoardCheck) || !Boolean(oldBoardCheck)) {
+    const error = new Error('해당 보드가 존재하지 않습니다.');
+    error.statusCode = 404;
+    throw error;
+  }
+  if (check.user_id !== userId) {
+    const error = new Error('해당 보드에 병합 할 권한이 없습니다.');
+    error.statusCode = 400;
+    throw error;
+  }
+  return await boardRepository.updateBoardStoreById(oldBoardId, newBoardId);
+};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 초기 세팅

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- oldBoardId(현재 접속 중인 보드 상세페이지의 id)와 newBoardId(현재 페이지의 pin들을 병합할 보드의 id)를 통해 보드 병합하기 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. oldBoardId, newBoardId 둘 다 존재하는 페이지인지 확인하고 아니라면 에러처리
2. 둘 다 로그인 한 회원의 보드인지 아닌지 확인 아닐 시 에러처리
3. prisma transaction API를 이용하여 여러 Pin들의 board_id가 업데이트 되는 것과 그 후 board 테이블에서 병합 처리된 board가 삭제되는 쿼리 2개를 트랜잭션 처리함.
4. 여러 row가 업데이트 되므로 prisma의 updatemany API 사용 

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

-

<br />

## :: 기타 질문 및 특이 사항

-
